### PR TITLE
Renames safe.Cat -> safe.Get

### DIFF
--- a/commands/cat.go
+++ b/commands/cat.go
@@ -31,7 +31,7 @@ func Cat(args ...string) int {
 		return handleError(err)
 	}
 
-	account, err := safe.Cat(args[0])
+	account, err := safe.Get(args[0])
 	if err != nil {
 		return handleError(err)
 	}

--- a/safe/get.go
+++ b/safe/get.go
@@ -4,7 +4,7 @@ import (
 	"github.com/bndw/pick/errors"
 )
 
-func (s *Safe) Cat(name string) (*Account, error) {
+func (s *Safe) Get(name string) (*Account, error) {
 	account, exists := s.Accounts[name]
 	if !exists {
 		return nil, &errors.AccountNotFound{}

--- a/safe/get_test.go
+++ b/safe/get_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 )
 
-func TestCat(t *testing.T) {
+func TestGet(t *testing.T) {
 	safe, err := createTestSafe()
 	if err != nil {
 		t.Error(err)
 	}
 	defer removeTestSafe()
 
-	if _, err = safe.Cat("foo"); err != nil {
+	if _, err = safe.Get("foo"); err != nil {
 		t.Error(err)
 	}
 }

--- a/safe/replace_test.go
+++ b/safe/replace_test.go
@@ -15,7 +15,7 @@ func TestReplace(t *testing.T) {
 		t.Error(err)
 	}
 
-	account, err := safe.Cat("foo")
+	account, err := safe.Get("foo")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Renames the Safe method for getting an account to `Get`, improving readability. This does not change the cli `cat` command.