### PR TITLE
Save safe file atomatically, i.e. write new safe to temporary file, thenrename this file

### DIFF
--- a/backends/disk.go
+++ b/backends/disk.go
@@ -54,7 +54,16 @@ func (db *DiskBackend) Load() ([]byte, error) {
 }
 
 func (db *DiskBackend) Save(data []byte) error {
-	return ioutil.WriteFile(db.path, data, defaultSafeFileMode)
+	tmpFile := db.path + ".tmp"
+	if err := ioutil.WriteFile(tmpFile, data, defaultSafeFileMode); err != nil {
+		os.Remove(tmpFile)
+		return err
+	}
+	if err := os.Rename(tmpFile, db.path); err != nil {
+		os.Remove(tmpFile)
+		return err
+	}
+	return nil
 }
 
 func defaultSafePath() (string, error) {


### PR DESCRIPTION
Rename is an atomic operation. So either the safe is updated, or it is not.
Currently, if there is a power outtage (or similar) during the write process, the safe can be destroyed.