### PR TITLE
use weak encryption in tests for speed

### DIFF
--- a/src/safe/utils_test.go
+++ b/src/safe/utils_test.go
@@ -47,7 +47,14 @@ func createTestSafe() (*Safe, error) {
 		return nil, err
 	}
 
-	cryptoConfig := crypto.NewDefaultConfig()
+	cryptoConfig := crypto.Config{
+		Type: crypto.ConfigTypeOpenPGP,
+		OpenPGPSettings: &crypto.OpenPGPSettings{
+			Cipher:   "aes128",
+			S2KCount: 1024,
+		},
+	}
+
 	cryptoClient, err := crypto.New(&cryptoConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Time to run Safe tests before: `2.940s`
Time to run Safe tests after: `0.012s`