### PR TITLE
Fix issue when generating a new password for an already existing account

### DIFF
--- a/src/safe/add.go
+++ b/src/safe/add.go
@@ -6,7 +6,8 @@ import (
 
 func (s *Safe) Add(name, username, password string) (*Account, error) {
 	if _, exists := s.Accounts[name]; exists {
-		return nil, &errors.AccountExists{}
+		account := s.Accounts[name]
+		return &account, &errors.AccountExists{}
 	}
 
 	account := NewAccount(name, username, password)


### PR DESCRIPTION
Issue was introduced in 86787659fd4a75bc2b1a1e02135afddd649a4899

Steps to reproduce:
```sh
$ pick add test test test
Add new account
$ pick add test test test
test already exists, overwrite (y/N)?
> y
Credential added
Copy password to clipboard (Y/n)?
> Y
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6fb5d]
```
