### PR TITLE
Don't allow to use a safe which is incompatible to the current version of pick

### DIFF
--- a/safe/load_test.go
+++ b/safe/load_test.go
@@ -28,6 +28,7 @@ func TestLoad(t *testing.T) {
 		conf := &config.Config{
 			Encryption: cryptoConfig,
 			Storage:    backendConfig,
+			Version:    "1.2.3",
 		}
 		for j, data := range safeData {
 			backendClient.Data = []byte(data)

--- a/safe/utils_test.go
+++ b/safe/utils_test.go
@@ -63,7 +63,7 @@ func createTestSafe() (*Safe, error) {
 	config := &config.Config{
 		Encryption: cryptoConfig,
 		Storage:    backendConfig,
-		Version:    "1.2.3 test",
+		Version:    "1.2.3",
 	}
 
 	return Load(

--- a/utils/versionparser.go
+++ b/utils/versionparser.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	versionSeparator = "."
+	versionLength    = 3
+)
+
+func ParseVersion(v string) ([]int, error) {
+	parts := make([]int, versionLength)
+	split := strings.SplitN(v, versionSeparator, versionLength)
+	if len(split) != versionLength {
+		return nil, fmt.Errorf("could not parse version '%s'", v)
+	}
+	// Remove 'v' from major version part
+	split[0] = strings.Replace(split[0], "v", "", 1)
+	for i, part := range split {
+		num, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, err
+		}
+		parts[i] = num
+	}
+	return parts, nil
+}


### PR DESCRIPTION
A pick version consists of three parts. E.g.:

```
1.2.3
_ 1: major version
  _ 2: minor version
    _ 3: patch version
```

If a safe is using a newer major/minor version than pick, reject the safe.
This makes sure you can't accidentally "destroy" a safe (e.g. losing an
account's history) by trying to use the safe with an older version of pick.
