### PR TITLE
Add 'init' command to initialize pick

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func init() {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "init",
+		Short: "Initialize pick",
+		Long:  "The init command is used to initialize pick.",
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommand(Init, cmd, args)
+		},
+	})
+}
+
+func Init(args []string, flags *pflag.FlagSet) error {
+	return initSafe()
+}

--- a/safe/init.go
+++ b/safe/init.go
@@ -1,0 +1,5 @@
+package safe
+
+func (s *Safe) Init() error {
+	return s.save()
+}


### PR DESCRIPTION
@bergart didn't find it intuitive to set up pick by using `pick add`.
New users now must `pick init` to set up a master password.