### PR TITLE
Prefer VISUAL over EDITOR to specify editor

### DIFF
--- a/safe/note.go
+++ b/safe/note.go
@@ -106,12 +106,19 @@ func NewEmptyNote(name string) note {
 	}
 }
 
-func editorReadText(existingText string) (string, error) {
-	editor := os.Getenv("EDITOR")
+func editorPath() (string, error) {
+	editor := os.Getenv("VISUAL")
 	if editor == "" {
-		editor = defaultNoteEditor
+		editor = os.Getenv("EDITOR")
+		if editor == "" {
+			editor = defaultNoteEditor
+		}
 	}
-	editorPath, err := exec.LookPath(editor)
+	return exec.LookPath(editor)
+}
+
+func editorReadText(existingText string) (string, error) {
+	editorPath, err := editorPath()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
With this commit, pick uses the programme specified by the [`VISUAL`](https://en.wikibooks.org/wiki/Guide_to_Unix/Environment_Variables#VISUAL) environment variable to edit notes. If `VISUAL` is not set, it will fall back to the previous behaviour of using the programme specified by the `EDITOR` environment variable, or vim if `EDITOR` is not set.