### PR TITLE
Fix typos

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 
 type generalConfig struct {
 	Password pswdgen.Config
-	// Warning: Deprecated. The PasswordLen field is required for backwards-compatiblity :(
+	// Warning: Deprecated. The PasswordLen field is required for backwards-compatibility :(
 	PasswordLen int
 }
 
@@ -55,7 +55,7 @@ func Load(version string) (*Config, error) {
 	}
 
 	config.Version = version
-	// Warning: Deprecated. The PasswordLen field is required for backwards-compatiblity :(
+	// Warning: Deprecated. The PasswordLen field is required for backwards-compatibility :(
 	if l := config.General.PasswordLen; l > 0 {
 		config.General.Password.Length = l
 	}

--- a/crypto/aes_gcm.go
+++ b/crypto/aes_gcm.go
@@ -22,7 +22,7 @@ type AESGCMSettings struct {
 	KeyDerivation string         `json:"keyderivation,omitempty" toml:"keyderivation"`
 	PBKDF2        *pbkdf2.PBKDF2 `json:"pbkdf2,omitempty" toml:"pbkdf2"`
 	Scrypt        *scrypt.Scrypt `json:"scrypt,omitempty" toml:"scrypt"`
-	// Warning: Deprecated. These three Pbkdf2 configs are required for backwards-compatiblity :(
+	// Warning: Deprecated. These three Pbkdf2 configs are required for backwards-compatibility :(
 	Pbkdf2Hash       string `json:"pbkdf2hash,omitempty" toml:"pbkdf2hash"`
 	Pbkdf2Iterations int    `json:"pbkdf2iterations,omitempty" toml:"pbkdf2iterations"`
 	Pbkdf2SaltLen    int    `json:"pbkdf2saltlen,omitempty" toml:"pbkdf2saltlen"`


### PR DESCRIPTION
Found with "gometalinter --vendor --disable-all --enable misspell ./..."