### PR TITLE
Explicitly assign all return values, even if we don't need them

### DIFF
--- a/backends/disk.go
+++ b/backends/disk.go
@@ -73,11 +73,11 @@ func (db *DiskBackend) Load() ([]byte, error) {
 func (db *DiskBackend) Save(data []byte) error {
 	tmpFile := db.path + ".tmp"
 	if err := ioutil.WriteFile(tmpFile, data, defaultSafeFileMode); err != nil {
-		os.Remove(tmpFile)
+		_ = os.Remove(tmpFile)
 		return err
 	}
 	if err := os.Rename(tmpFile, db.path); err != nil {
-		os.Remove(tmpFile)
+		_ = os.Remove(tmpFile)
 		return err
 	}
 	return nil
@@ -132,7 +132,7 @@ func min(a, b int) int {
 func (db *DiskBackend) Backup() error {
 	if db.backupConfig.MaxFiles == 0 {
 		// Keep no backups
-		db.cleanOldBackups(0)
+		_ = db.cleanOldBackups(0)
 		return errors.ErrBackupDisabled
 	} else if db.backupConfig.MaxFiles > 0 {
 		// Subtract one as we are about to create another backup

--- a/backends/s3.go
+++ b/backends/s3.go
@@ -111,7 +111,7 @@ func (s *S3Backend) Load() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer result.Close()
+	defer result.Close() // nolint: errcheck
 
 	buf := bytes.NewBuffer(nil)
 	if _, err := io.Copy(buf, result); err != nil {

--- a/commands/util.go
+++ b/commands/util.go
@@ -18,7 +18,7 @@ import (
 func runCommand(c func([]string, *pflag.FlagSet) error, cmd *cobra.Command, args []string) {
 	if err := c(args, cmd.Flags()); err != nil {
 		if err == errors.ErrInvalidCommandUsage {
-			cmd.Usage()
+			_ = cmd.Usage()
 			os.Exit(1)
 		}
 		os.Exit(handleError(err))

--- a/crypto/openpgp.go
+++ b/crypto/openpgp.go
@@ -110,13 +110,13 @@ func (c *OpenPGPClient) Encrypt(plaintext []byte, password []byte) (ciphertext [
 	if err != nil {
 		return
 	}
-	defer w.Close()
+	defer w.Close() // nolint: errcheck
 
 	pt, err := openpgp.SymmetricallyEncrypt(w, password, nil, c.packetConfig)
 	if err != nil {
 		return
 	}
-	defer pt.Close()
+	defer pt.Close() // nolint: errcheck
 
 	if _, err := pt.Write(plaintext); err != nil {
 		return nil, err

--- a/safe/save.go
+++ b/safe/save.go
@@ -27,7 +27,7 @@ func (s *Safe) save() error {
 
 	// Before saving the new safe, do an auto-backup if enabled
 	if s.Config.Storage.Backup.AutoEnabled {
-		Backup(s.backend)
+		_ = Backup(s.backend)
 	}
 
 	return s.backend.Save(data)

--- a/utils/format.go
+++ b/utils/format.go
@@ -12,7 +12,7 @@ func PrettyPrint(v interface{}) {
 		panic(err)
 	}
 
-	os.Stdout.Write(b)
+	_, _ = os.Stdout.Write(b)
 }
 
 func FormatUnixTime(ts int64) string {

--- a/utils/pswdgen/generator.go
+++ b/utils/pswdgen/generator.go
@@ -138,13 +138,22 @@ func Generate(config Config) (string, error) {
 }
 
 func readTermChar() ([]byte, error) {
-	t, _ := term.Open("/dev/tty")
-	term.RawMode(t)
+	t, err := term.Open("/dev/tty")
+	if err != nil {
+		return nil, err
+	}
+	if err := term.RawMode(t); err != nil {
+		return nil, err
+	}
 	bytes := make([]byte, 3)
 	numRead, err := t.Read(bytes)
-	t.Restore()
-	t.Close()
 	if err != nil {
+		return nil, err
+	}
+	if err := t.Restore(); err != nil {
+		return nil, err
+	}
+	if err := t.Close(); err != nil {
 		return nil, err
 	}
 	return bytes[0:numRead], nil


### PR DESCRIPTION
Found with "gometalinter --vendor --disable-all --enable errcheck ./..."