### PR TITLE
Automatically clear the clipboard

### DIFF
--- a/commands/add.go
+++ b/commands/add.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bndw/pick/errors"
 	"github.com/bndw/pick/strings"
 	"github.com/bndw/pick/utils"
+	"github.com/bndw/pick/utils/clipboard"
 	"github.com/bndw/pick/utils/pswdgen"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -45,7 +46,7 @@ func Add(args []string, flags *pflag.FlagSet) error {
 
 	fmt.Println("Credential added")
 	if utils.Confirm("Copy password to clipboard", true) {
-		if err := utils.CopyToClipboard(account.Password); err != nil {
+		if err := clipboard.CopyWithClearing(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
 			return err
 		}
 		fmt.Println(strings.PasswordCopiedToClipboard)

--- a/commands/add.go
+++ b/commands/add.go
@@ -46,7 +46,7 @@ func Add(args []string, flags *pflag.FlagSet) error {
 
 	fmt.Println("Credential added")
 	if utils.Confirm("Copy password to clipboard", true) {
-		if err := clipboard.CopyWithClearing(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
+		if err := clipboard.Copy(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
 			return err
 		}
 		fmt.Println(strings.PasswordCopiedToClipboard)

--- a/commands/clear_clipboard.go
+++ b/commands/clear_clipboard.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/bndw/pick/errors"
+	"github.com/bndw/pick/utils/clipboard"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func init() {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "clear-clipboard [after-seconds] [must-match]",
+		Short: "Clear clipboard",
+		Long:  "The clear-clipboard command is used to clear the clipboard.",
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommand(ClearClipboard, cmd, args)
+		},
+		Hidden: true,
+	})
+}
+
+func ClearClipboard(args []string, flags *pflag.FlagSet) error {
+	duration, match, err := parseClearClipboardArgs(args)
+	if err != nil {
+		return err
+	}
+	time.Sleep(duration)
+	return clipboard.ClearIfMatch(match)
+}
+
+func parseClearClipboardArgs(args []string) (duration time.Duration, match string, err error) {
+	if len(args) != 2 {
+		err = errors.ErrInvalidCommandUsage
+		return
+	}
+
+	var secs int64
+	secs, err = strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return
+	}
+	duration = time.Duration(secs) * time.Second
+
+	match = args[1]
+
+	return
+}

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -37,7 +37,7 @@ func Copy(args []string, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := clipboard.CopyWithClearing(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
+	if err := clipboard.Copy(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
 		return err
 	}
 	fmt.Println(strings.PasswordCopiedToClipboard)

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bndw/pick/errors"
 	"github.com/bndw/pick/strings"
-	"github.com/bndw/pick/utils"
+	"github.com/bndw/pick/utils/clipboard"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -37,7 +37,7 @@ func Copy(args []string, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := utils.CopyToClipboard(account.Password); err != nil {
+	if err := clipboard.CopyWithClearing(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
 		return err
 	}
 	fmt.Println(strings.PasswordCopiedToClipboard)

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -41,7 +41,7 @@ func Edit(args []string, flags *pflag.FlagSet) error {
 
 	fmt.Println("Credential updated")
 	if utils.Confirm("Copy password to clipboard", true) {
-		if err := clipboard.CopyWithClearing(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
+		if err := clipboard.Copy(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
 			return err
 		}
 		fmt.Println(strings.PasswordCopiedToClipboard)

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bndw/pick/errors"
 	"github.com/bndw/pick/strings"
 	"github.com/bndw/pick/utils"
+	"github.com/bndw/pick/utils/clipboard"
 	"github.com/bndw/pick/utils/pswdgen"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -40,7 +41,7 @@ func Edit(args []string, flags *pflag.FlagSet) error {
 
 	fmt.Println("Credential updated")
 	if utils.Confirm("Copy password to clipboard", true) {
-		if err := utils.CopyToClipboard(account.Password); err != nil {
+		if err := clipboard.CopyWithClearing(account.Password, safe.Config.General.Clipboard.ClearAfter); err != nil {
 			return err
 		}
 		fmt.Println(strings.PasswordCopiedToClipboard)

--- a/config.toml.in
+++ b/config.toml.in
@@ -21,6 +21,9 @@
 #   #  - Decrease length via: Left-arrow key / "h"
 #   #  - Use current password: Enter key
 #   mode = "interactive"
+#   [general.clipboard]
+#   # Specifies the time after which the clipboard is cleared.
+#   clearAfter = "90s"
 
 
 ## Storage
@@ -35,7 +38,7 @@ type = "file"
   # The number of backups to keep.
   # Specify -1 to allow unlimited backups, 0 to not create backups at all.
   #max = 100
-  
+
 # type = "s3"
 #   [storage.settings]
 #   # Name of AWS S3 bucket

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/bndw/pick/backends"
 	"github.com/bndw/pick/crypto"
+	"github.com/bndw/pick/utils/clipboard"
 	"github.com/bndw/pick/utils/pswdgen"
 	"github.com/mitchellh/go-homedir"
 )
@@ -26,6 +27,7 @@ type generalConfig struct {
 	Password pswdgen.Config
 	// Warning: Deprecated. The PasswordLen field is required for backwards-compatibility :(
 	PasswordLen int
+	Clipboard   clipboard.Config
 }
 
 func Load(version string) (*Config, error) {
@@ -39,7 +41,8 @@ func Load(version string) (*Config, error) {
 		Storage:    backends.NewDefaultConfig(),
 		Encryption: crypto.NewDefaultConfig(),
 		General: generalConfig{
-			Password: pswdgen.NewDefaultConfig(),
+			Password:  pswdgen.NewDefaultConfig(),
+			Clipboard: clipboard.NewDefaultConfig(),
 		},
 	}
 	if _, err := os.Stat(configFile); err != nil {

--- a/utils/clipboard.go
+++ b/utils/clipboard.go
@@ -1,9 +1,0 @@
-package utils
-
-import (
-	"github.com/atotto/clipboard"
-)
-
-func CopyToClipboard(text string) error {
-	return clipboard.WriteAll(text)
-}

--- a/utils/clipboard/clipboard.go
+++ b/utils/clipboard/clipboard.go
@@ -1,0 +1,63 @@
+package clipboard
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+
+	otherClipboard "github.com/atotto/clipboard"
+)
+
+const (
+	clearClipboardCmd = "clear-clipboard"
+	hashLen           = 4 // in bytes
+)
+
+func CopyWithClearing(text string, clearAfter Duration) error {
+	if clearAfter.Seconds() > 0 {
+		// Clear the clipboard after 'clearAfter'
+		_ = launchClearer(text, clearAfter)
+	}
+	return otherClipboard.WriteAll(text)
+}
+
+func ClearIfMatch(match string) error {
+	// We're about to clear the clipboard
+	// Ensure that we still have the expected contents in it
+	// This avoids clearing other data which have been copied in the meantime
+	current, err := otherClipboard.ReadAll()
+	if err != nil {
+		return fmt.Errorf("failed to read current clipboard content: %s", err)
+	}
+	currentHashed := hashCurrentAsHex(current)
+	if subtle.ConstantTimeCompare([]byte(currentHashed), []byte(match)) != 1 {
+		return errors.New("not clearing clipboard as content has changed")
+	}
+	return CopyWithClearing("", Duration{-1})
+}
+
+func launchClearer(current string, duration Duration) error {
+	currentHashed := hashCurrentAsHex(current)
+
+	pickPath, err := exec.LookPath("pick")
+	if err != nil {
+		return fmt.Errorf("failed to find 'pick' binary: %s", err)
+	}
+	secs := strconv.FormatInt(int64(duration.Seconds()), 10)
+	cmd := exec.Command(pickPath, clearClipboardCmd, secs, currentHashed)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start 'pick': %s", err)
+	}
+	// Don't cmd.Wait() to run as background process
+	return nil
+}
+
+func hashCurrentAsHex(current string) string {
+	h := sha256.New()
+	h.Write([]byte(current))
+	return hex.EncodeToString(h.Sum(nil)[:hashLen])
+}

--- a/utils/clipboard/clipboard.go
+++ b/utils/clipboard/clipboard.go
@@ -17,6 +17,9 @@ const (
 	hashLen           = 4 // in bytes
 )
 
+// CopyWithClearing copies the provided text to the system clipboard
+// If clearAfter is given and larger 0, the clipboard is automatically
+// cleared after the duration has passed
 func CopyWithClearing(text string, clearAfter Duration) error {
 	if clearAfter.Seconds() > 0 {
 		// Clear the clipboard after 'clearAfter'
@@ -25,6 +28,8 @@ func CopyWithClearing(text string, clearAfter Duration) error {
 	return otherClipboard.WriteAll(text)
 }
 
+// ClearIfMatch clears the clipboard if its current content's truncated
+// hash equals 'match'
 func ClearIfMatch(match string) error {
 	// We're about to clear the clipboard
 	// Ensure that we still have the expected contents in it

--- a/utils/clipboard/clipboard.go
+++ b/utils/clipboard/clipboard.go
@@ -17,10 +17,10 @@ const (
 	hashLen           = 4 // in bytes
 )
 
-// CopyWithClearing copies the provided text to the system clipboard
+// Copy copies the provided text to the system clipboard
 // If clearAfter is given and larger 0, the clipboard is automatically
 // cleared after the duration has passed
-func CopyWithClearing(text string, clearAfter Duration) error {
+func Copy(text string, clearAfter Duration) error {
 	if clearAfter.Seconds() > 0 {
 		// Clear the clipboard after 'clearAfter'
 		_ = launchClearer(text, clearAfter)
@@ -42,7 +42,7 @@ func ClearIfMatch(match string) error {
 	if subtle.ConstantTimeCompare([]byte(currentHashed), []byte(match)) != 1 {
 		return errors.New("not clearing clipboard as content has changed")
 	}
-	return CopyWithClearing("", Duration{-1})
+	return Copy("", Duration{-1})
 }
 
 func launchClearer(current string, duration Duration) error {

--- a/utils/clipboard/config.go
+++ b/utils/clipboard/config.go
@@ -1,0 +1,19 @@
+package clipboard
+
+import (
+	"time"
+)
+
+const (
+	defaultClearAfter = 90 * time.Second
+)
+
+type Config struct {
+	ClearAfter Duration `toml:"clearAfter"`
+}
+
+func NewDefaultConfig() Config {
+	return Config{
+		ClearAfter: Duration{defaultClearAfter},
+	}
+}

--- a/utils/clipboard/duration.go
+++ b/utils/clipboard/duration.go
@@ -1,0 +1,19 @@
+package clipboard
+
+import (
+	"time"
+)
+
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}
+
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}


### PR DESCRIPTION
Automatically clear the system keyboard after 90 seconds. This value
is configurable. The clipboard is only cleared if it still contains
the content which was originally copied.
To not leak any valueable information about the copied contents,
the clearing background process only receives a truncated hash of
the data which he compares against the (possibly) altered clipboard
contents. Only if they match, the clipboard is wiped.