### PR TITLE
Remove separate brew tap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ go get -u github.com/bndw/pick
 
 #### Homebrew
 ```sh
-brew tap bndw/pick
 brew install bndw/pick/pick-pass
 ```
 


### PR DESCRIPTION
brew will clone the tap if it has not already been cloned when `brew install bndw/pick/pick-pass` is called:

```sh
$ brew install bndw/pick/pick-pass
==> Tapping bndw/pick
Cloning into '/usr/local/Homebrew/Library/Taps/bndw/homebrew-pick'...
remote: Counting objects: 4, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Tapped 1 formula (28 files, 20.8KB)
==> Installing pick-pass from bndw/pick
==> Downloading https://github.com/bndw/pick/archive/v0.6.0.tar.gz
==> Downloading from https://codeload.github.com/bndw/pick/tar.gz/v0.6.0
######################################################################## 100.0%
==> make
🍺  /usr/local/Cellar/pick-pass/0.6.0: 5 files, 14MB, built in 14 seconds
```