### PR TITLE
Use consistent 'import' syntax

### DIFF
--- a/backends/s3.go
+++ b/backends/s3.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-
 	"github.com/bndw/pick/errors"
 )
 

--- a/crypto/chacha20poly1305.go
+++ b/crypto/chacha20poly1305.go
@@ -5,11 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"golang.org/x/crypto/chacha20poly1305"
-
 	"github.com/bndw/pick/crypto/pbkdf2"
 	"github.com/bndw/pick/crypto/scrypt"
 	"github.com/bndw/pick/errors"
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 type ChaCha20Poly1305Client struct {


### PR DESCRIPTION
That is, don't group non-stdlib imports.