### PR TITLE
crypto/pbkdf2: Check error return value

### DIFF
--- a/crypto/pbkdf2/pbkdf2.go
+++ b/crypto/pbkdf2/pbkdf2.go
@@ -59,7 +59,10 @@ func (p *PBKDF2) DeriveKey(password []byte, keyLen int) ([]byte, []byte, error) 
 		return nil, nil, err
 	}
 
-	key, _ := p.DeriveKeyWithSalt(password, salt, keyLen)
+	key, err := p.DeriveKeyWithSalt(password, salt, keyLen)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return key, salt, nil
 }


### PR DESCRIPTION
Check error return value of 'DeriveKeyWithSalt', even though it
currently always returns nil.