### PR TITLE
safe/add: Check error return value

### DIFF
--- a/safe/add.go
+++ b/safe/add.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (s *Safe) Add(name, username, password string) (*Account, error) {
-	if existingAccount, _ := s.Get(name); existingAccount != nil {
+	if existingAccount, err := s.Get(name); err == nil {
 		return existingAccount, errors.ErrAccountAlreadyExists
 	}
 


### PR DESCRIPTION
Check error return value of 'Get' instead of relying on a non-nil
'account' return value.