### PR TITLE
config: Don't export optional fields in JSON

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,9 +17,9 @@ const (
 )
 
 type Config struct {
-	Encryption crypto.Config
-	Storage    backends.Config
-	General    generalConfig
+	Encryption crypto.Config   `json:"-"`
+	Storage    backends.Config `json:"-"`
+	General    generalConfig   `json:"-"`
 	Version    string
 }
 


### PR DESCRIPTION
These fields would otherwise land in the encrypted safe where they
are not needed.