### PR TITLE
Only allow running a single pick instance concurrently

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -69,6 +69,11 @@
   version = "v1.0"
 
 [[projects]]
+  name = "github.com/marcsauter/single"
+  packages = ["."]
+  revision = "3f6ac6766709f17b529a516abd96745824431eb0"
+
+[[projects]]
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"

--- a/backends/client.go
+++ b/backends/client.go
@@ -5,6 +5,10 @@ type Client interface {
 	Save(data []byte) error
 	Backup() error
 	SafeLocation() string
+	IsWritable() bool
+	SetWritable(writable bool) error
+	Lock() error
+	Unlock() error
 }
 
 func New(config *Config) (Client, error) {

--- a/backends/file/new.go
+++ b/backends/file/new.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 
 	"github.com/bndw/pick/backends"
+	"github.com/marcsauter/single"
 	homedir "github.com/mitchellh/go-homedir"
+)
+
+const (
+	lockFileName = "pick"
 )
 
 func _new(config *backends.Config) (backends.Client, error) {
@@ -27,10 +32,14 @@ func _new(config *backends.Config) (backends.Client, error) {
 
 	config.Backup.DirPath = fmt.Sprintf(defaultBackupDir, homeDir, defaultSafeDirName)
 
-	return &client{
+	lock := single.New(lockFileName)
+	c := &client{
+		lock:         lock,
 		path:         safePath,
 		backupConfig: config.Backup,
-	}, nil
+	}
+
+	return c, nil
 }
 
 func formatHomeDir(str, home string) string {

--- a/backends/mock/client.go
+++ b/backends/mock/client.go
@@ -1,7 +1,13 @@
 package mock
 
+import (
+	"github.com/bndw/pick/errors"
+)
+
 // client is used for tests
 type client struct {
+	writable bool
+
 	Data []byte
 }
 
@@ -10,6 +16,10 @@ func (c *client) Load() ([]byte, error) {
 }
 
 func (c *client) Save(ciphertext []byte) error {
+	if !c.writable {
+		return errors.ErrSafeNotWritable
+	}
+
 	c.Data = ciphertext
 	return nil
 }
@@ -20,4 +30,21 @@ func (c *client) Backup() error {
 
 func (c *client) SafeLocation() string {
 	return "mock-safe-location"
+}
+
+func (c *client) IsWritable() bool {
+	return c.writable
+}
+
+func (c *client) SetWritable(writable bool) error {
+	c.writable = writable
+	return nil
+}
+
+func (c *client) Lock() error {
+	return nil
+}
+
+func (c *client) Unlock() error {
+	return nil
 }

--- a/backends/mock/client_test.go
+++ b/backends/mock/client_test.go
@@ -12,13 +12,13 @@ var (
 )
 
 func TestNewBackend(t *testing.T) {
-	if b := mockBackend.NewForTesting(t, nil); b == nil {
+	if b := mockBackend.NewForTesting(t, nil, false); b == nil {
 		t.Errorf("Expected new mockBackend, got nil")
 	}
 }
 
 func TestMockBackup(t *testing.T) {
-	b := mockBackend.NewForTesting(t, nil)
+	b := mockBackend.NewForTesting(t, nil, false)
 
 	if err := b.Backup(); err != nil {
 		t.Errorf("Backup failed with %s", err)
@@ -26,7 +26,7 @@ func TestMockBackup(t *testing.T) {
 }
 
 func TestMockLoad(t *testing.T) {
-	b := mockBackend.NewForTesting(t, nil)
+	b := mockBackend.NewForTesting(t, nil, false)
 	b.Data = mockTestData
 
 	data, err := b.Load()
@@ -39,7 +39,7 @@ func TestMockLoad(t *testing.T) {
 }
 
 func TestMockSave(t *testing.T) {
-	b := mockBackend.NewForTesting(t, nil)
+	b := mockBackend.NewForTesting(t, nil, true)
 
 	if err := b.Save(mockTestData); err != nil {
 		t.Errorf("Load failed with %s", err)

--- a/backends/mock/new.go
+++ b/backends/mock/new.go
@@ -19,7 +19,7 @@ Jn766KqjJFAUxwvguuNHI0fMMcIyfeA+4uNDsmXg+uRsGhwVdCP509FRtqes0EPh
 	return &client{Data: safeData}, nil
 }
 
-func NewForTesting(t *testing.T, config *backends.Config) *client {
+func NewForTesting(t *testing.T, config *backends.Config, writable bool) *client {
 	// t.Helper() // TOOD(leon): Go 1.9 only :(
 	if config == nil {
 		tmp := backends.NewDefaultConfig()
@@ -32,5 +32,6 @@ func NewForTesting(t *testing.T, config *backends.Config) *client {
 	if err != nil {
 		t.Fatalf("Failed to create mock backend: %v", err)
 	}
+	c.SetWritable(writable)
 	return c.(*client)
 }

--- a/backends/s3/client.go
+++ b/backends/s3/client.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"bytes"
+	builtinerrors "errors"
 	"fmt"
 	"io"
 	"time"
@@ -29,6 +30,8 @@ const (
 //		AWS_REGION
 //
 type client struct {
+	writable bool
+
 	Bucket string
 	Key    string
 	svc    *s3.S3
@@ -52,6 +55,10 @@ func (c *client) Load() ([]byte, error) {
 
 // Save writes data to S3
 func (c *client) Save(data []byte) error {
+	if !c.writable {
+		return errors.ErrSafeNotWritable
+	}
+
 	return c.putObject(bytes.NewReader(data), c.Bucket, c.Key)
 }
 
@@ -73,6 +80,26 @@ func (c *client) Backup() error {
 	}
 
 	return c.putObject(bytes.NewReader(data), c.Bucket, backupKey)
+}
+
+func (c *client) IsWritable() bool {
+	return c.writable
+}
+
+func (c *client) SetWritable(writable bool) error {
+	c.writable = writable
+	// TODO: Implement me!
+	return builtinerrors.New("not implemented")
+}
+
+func (c *client) Lock() error {
+	// TODO: Implement me!
+	return builtinerrors.New("not implemented")
+}
+
+func (c *client) Unlock() error {
+	// TODO: Implement me!
+	return builtinerrors.New("not implemented")
 }
 
 func (c *client) getObject(bucket, key string) (io.ReadCloser, error) {

--- a/commands/add.go
+++ b/commands/add.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func Add(args []string, flags *pflag.FlagSet) error {
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(true).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/cat.go
+++ b/commands/cat.go
@@ -64,7 +64,7 @@ func Cat(args []string, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(false).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -27,7 +27,7 @@ func Copy(args []string, flags *pflag.FlagSet) error {
 	}
 	name := args[0]
 
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(false).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func Edit(args []string, flags *pflag.FlagSet) error {
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(true).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/export.go
+++ b/commands/export.go
@@ -25,7 +25,7 @@ func Export(args []string, flags *pflag.FlagSet) error {
 		return errors.New("Aborted as requested")
 	}
 
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(false).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func List(args []string, flags *pflag.FlagSet) error {
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(false).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/move.go
+++ b/commands/move.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func Move(args []string, flags *pflag.FlagSet) error {
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(true).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/note.go
+++ b/commands/note.go
@@ -41,13 +41,13 @@ func Note(args []string, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	if action == "edit" {
-		fmt.Printf("You are about to add or edit a note named '%s'\n", name)
-	}
-
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(true).Load()
 	if err != nil {
 		return err
+	}
+
+	if action == "edit" {
+		fmt.Printf("You are about to add or edit a note named '%s'\n", name)
 	}
 
 	switch action {

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -25,7 +25,7 @@ func Remove(args []string, flags *pflag.FlagSet) error {
 	}
 	name := args[0]
 
-	safe, err := newSafeLoader().Load()
+	safe, err := newSafeLoader(true).Load()
 	if err != nil {
 		return err
 	}

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -25,7 +25,7 @@ func Sync(args []string, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	safeLoader := newSafeLoader()
+	safeLoader := newSafeLoader(true)
 
 	safe, err := safeLoader.Load()
 	if err != nil {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrSafeNotFound         = errors.New("Safe not found")
 	ErrSafeCorrupt          = errors.New("Safe currupt")
 	ErrSafeDecryptionFailed = errors.New("Unable to unlock safe with provided password")
+	ErrSafeNotWritable      = errors.New("Safe not writable, this should never happen")
 
 	ErrBackupDisabled   = errors.New("Backups are disabled, increase `max_backups` to re-enable")
 	ErrBackupFileExists = errors.New("Backup file already exists")
@@ -16,4 +17,6 @@ var (
 	ErrAccountNotFound      = errors.New("Account not found")
 
 	ErrInvalidCommandUsage = errors.New("Invalid use of command")
+
+	ErrAlreadyRunning = errors.New("Another instance of pick is already running. To prevent data loss, only a single pick-instance is allowed.")
 )

--- a/safe/add_test.go
+++ b/safe/add_test.go
@@ -11,7 +11,7 @@ const (
 )
 
 func TestAdd(t *testing.T) {
-	safe, err := createTestSafe(t)
+	safe, err := createTestSafe(t, true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/safe/edit_test.go
+++ b/safe/edit_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestEdit(t *testing.T) {
-	safe, err := createTestSafe(t)
+	safe, err := createTestSafe(t, true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/safe/get_test.go
+++ b/safe/get_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	safe, err := createTestSafe(t)
+	safe, err := createTestSafe(t, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/safe/list_test.go
+++ b/safe/list_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestList(t *testing.T) {
-	safe, err := createTestSafe(t)
+	safe, err := createTestSafe(t, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/safe/load.go
+++ b/safe/load.go
@@ -65,6 +65,12 @@ func Load(password []byte, backendClient backends.Client, cryptoClient crypto.Cl
 	}
 
 	if configChanged {
+		w := backendClient.IsWritable()
+		// Make safe writable
+		backendClient.SetWritable(true)
+		// Restore old mode
+		defer backendClient.SetWritable(w)
+
 		fmt.Println("Upgrading safe")
 		if err := s.save(); err != nil { // nolint: vetshadow
 			fmt.Println("Error saving safe", err.Error())

--- a/safe/load_test.go
+++ b/safe/load_test.go
@@ -44,7 +44,7 @@ func TestLoadWithUpdatedConfig(t *testing.T) {
 		Storage:    backends.NewDefaultConfig(),
 		Version:    "0.6.0",
 	}
-	backendClient := mockBackend.NewForTesting(t, &conf.Storage)
+	backendClient := mockBackend.NewForTesting(t, &conf.Storage, false)
 	backendClient.Data = data
 
 	s, err := safe.Load([]byte(password), backendClient, cryptoClient, conf)
@@ -64,7 +64,7 @@ func TestLoadWithUpdatedConfig(t *testing.T) {
 
 func TestLoad(t *testing.T) {
 	backendConfig := backends.NewDefaultConfig()
-	backendClient := mockBackend.NewForTesting(t, &backendConfig)
+	backendClient := mockBackend.NewForTesting(t, &backendConfig, false)
 	for i, cryptoConfig := range safeCryptoConfigs {
 		cryptoClient, err := crypto.New(&cryptoConfig)
 		if err != nil {

--- a/safe/move_test.go
+++ b/safe/move_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMove(t *testing.T) {
-	safe, err := createTestSafe(t)
+	safe, err := createTestSafe(t, true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/safe/remove_test.go
+++ b/safe/remove_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestRemove(t *testing.T) {
-	safe, err := createTestSafe(t)
+	safe, err := createTestSafe(t, true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/safe/sync_test.go
+++ b/safe/sync_test.go
@@ -16,11 +16,11 @@ const (
 )
 
 func TestSyncSameHistory(t *testing.T) {
-	safe1, err := createTestSafe(t)
+	safe1, err := createTestSafe(t, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	safe2, err := createTestSafe(t)
+	safe2, err := createTestSafe(t, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,11 +77,11 @@ func TestSyncSameHistory(t *testing.T) {
 }
 
 func TestSyncDifferentHistory(t *testing.T) {
-	safe1, err := createTestSafe(t)
+	safe1, err := createTestSafe(t, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	safe2, err := createTestSafe(t)
+	safe2, err := createTestSafe(t, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/safe/utils_test.go
+++ b/safe/utils_test.go
@@ -22,11 +22,11 @@ Jn766KqjJFAUxwvguuNHI0fMMcIyfeA+4uNDsmXg+uRsGhwVdCP509FRtqes0EPh
 -----END PGP MESSAGE-----`
 )
 
-func createTestSafe(t *testing.T) (*Safe, error) {
+func createTestSafe(t *testing.T, writable bool) (*Safe, error) {
 	// t.Helper() // TOOD(leon): Go 1.9 only :(
 
 	backendConfig := backends.NewDefaultConfig()
-	backendClient := mockBackend.NewForTesting(t, &backendConfig)
+	backendClient := mockBackend.NewForTesting(t, &backendConfig, writable)
 	backendClient.Data = []byte(testSafeContent)
 
 	cryptoConfig := crypto.Config{

--- a/vendor/github.com/marcsauter/single/README.md
+++ b/vendor/github.com/marcsauter/single/README.md
@@ -1,0 +1,23 @@
+# single
+
+`single` provides a mechanism to ensure, that only one instance of a program is running.
+
+    package main
+
+    import (
+        "log"
+        "time"
+
+        "github.com/marcsauter/single"
+    )
+
+    func main() {
+        s := single.New("name")
+        s.Lock()
+        defer s.Unlock()
+        log.Println("working")
+        time.Sleep(60 * time.Second)
+        log.Println("finished")
+    }
+
+The package currently supports `linux`, `solaris` and `windows`.

--- a/vendor/github.com/marcsauter/single/single.go
+++ b/vendor/github.com/marcsauter/single/single.go
@@ -1,0 +1,41 @@
+// package single provides a mechanism to ensure, that only one instance of a program is running
+
+package single
+
+import (
+	"errors"
+	"log"
+	"os"
+)
+
+var (
+	// ErrAlreadyRunning -- the instance is already running
+	ErrAlreadyRunning = errors.New("the program is already running")
+	// Lockfile -- the lock file to check
+	Lockfile string
+)
+
+// Single represents the name and the open file descriptor
+type Single struct {
+	name string
+	file *os.File
+}
+
+// New creates a Single instance
+func New(name string) *Single {
+	return &Single{name: name}
+}
+
+// Lock tries to obtain an exclude lock on a lockfile and exits the program if an error occurs
+func (s *Single) Lock() {
+	if err := s.CheckLock(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Unlock releases the lock, closes and removes the lockfile. All errors will be reported directly.
+func (s *Single) Unlock() {
+	if err := s.TryUnlock(); err != nil {
+		log.Print(err)
+	}
+}

--- a/vendor/github.com/marcsauter/single/single_darwin.go
+++ b/vendor/github.com/marcsauter/single/single_darwin.go
@@ -1,0 +1,15 @@
+package single
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Filename returns an absolute filename, appropriate for the operating system
+func (s *Single) Filename() string {
+	if len(Lockfile) > 0 {
+		return Lockfile
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s.lock", s.name))
+}

--- a/vendor/github.com/marcsauter/single/single_freebsd.go
+++ b/vendor/github.com/marcsauter/single/single_freebsd.go
@@ -1,0 +1,14 @@
+package single
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Filename returns an absolute filename, appropriate for the operating system
+func (s *Single) Filename() string {
+	if len(Lockfile) > 0 {
+		return Lockfile
+	}
+	return filepath.Join("/var/run", fmt.Sprintf("%s.lock", s.name))
+}

--- a/vendor/github.com/marcsauter/single/single_linux.go
+++ b/vendor/github.com/marcsauter/single/single_linux.go
@@ -1,0 +1,14 @@
+package single
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Filename returns an absolute filename, appropriate for the operating system
+func (s *Single) Filename() string {
+	if len(Lockfile) > 0 {
+		return Lockfile
+	}
+	return filepath.Join("/var/lock", fmt.Sprintf("%s.lock", s.name))
+}

--- a/vendor/github.com/marcsauter/single/single_solaris.go
+++ b/vendor/github.com/marcsauter/single/single_solaris.go
@@ -1,0 +1,14 @@
+package single
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Filename returns an absolute filename, appropriate for the operating system
+func (s *Single) Filename() string {
+	if len(Lockfile) > 0 {
+		return Lockfile
+	}
+	return filepath.Join("/var/run", fmt.Sprintf("%s.lock", s.name))
+}

--- a/vendor/github.com/marcsauter/single/single_unix.go
+++ b/vendor/github.com/marcsauter/single/single_unix.go
@@ -1,0 +1,50 @@
+// +build linux solaris darwin freebsd
+
+package single
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// CheckLock tries to obtain an exclude lock on a lockfile and returns an error if one occurs
+func (s *Single) CheckLock() error {
+
+	// open/create lock file
+	f, err := os.OpenFile(s.Filename(), os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+	s.file = f
+	// set the lock type to F_WRLCK, therefor the file has to be opened writable
+	flock := syscall.Flock_t{
+		Type: syscall.F_WRLCK,
+		Pid:  int32(os.Getpid()),
+	}
+	// try to obtain an exclusive lock - FcntlFlock seems to be the portable *ix way
+	if err := syscall.FcntlFlock(s.file.Fd(), syscall.F_SETLK, &flock); err != nil {
+		return ErrAlreadyRunning
+	}
+
+	return nil
+}
+
+// TryUnlock unlocks, closes and removes the lockfile
+func (s *Single) TryUnlock() error {
+	// set the lock type to F_UNLCK
+	flock := syscall.Flock_t{
+		Type: syscall.F_UNLCK,
+		Pid:  int32(os.Getpid()),
+	}
+	if err := syscall.FcntlFlock(s.file.Fd(), syscall.F_SETLK, &flock); err != nil {
+		return fmt.Errorf("failed to unlock the lock file: %v", err)
+	}
+	if err := s.file.Close(); err != nil {
+		return fmt.Errorf("failed to close the lock file: %v", err)
+	}
+	if err := os.Remove(s.Filename()); err != nil {
+		return fmt.Errorf("failed to remove the lock file: %v", err)
+	}
+	return nil
+}

--- a/vendor/github.com/marcsauter/single/single_windows.go
+++ b/vendor/github.com/marcsauter/single/single_windows.go
@@ -1,0 +1,44 @@
+// +build windows
+
+package single
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Filename returns an absolute filename, appropriate for the operating system
+func (s *Single) Filename() string {
+	if len(Lockfile) > 0 {
+		return Lockfile
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s.lock", s.name))
+}
+
+// CheckLock tries to obtain an exclude lock on a lockfile and returns an error if one occurs
+func (s *Single) CheckLock() error {
+
+	if err := os.Remove(s.Filename()); err != nil && !os.IsNotExist(err) {
+		return ErrAlreadyRunning
+	}
+
+	file, err := os.OpenFile(s.Filename(), os.O_EXCL|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+	s.file = file
+
+	return nil
+}
+
+// TryUnlock closes and removes the lockfile
+func (s *Single) TryUnlock() error {
+	if err := s.file.Close(); err != nil {
+		return fmt.Errorf("failed to close the lock file: %v", err)
+	}
+	if err := os.Remove(s.Filename()); err != nil {
+		return fmt.Errorf("failed to remove the lock file: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
To prevent data loss, only a single pick instance should be running
at the same time.
Without this patch, if an active "pick note" editor is open and
new credentials are stored in a pick safe, closing the "pick note"
editor will overwrite all changes happened since.