### PR TITLE
dep: Pin all dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,14 +8,39 @@
   version = "v0.3.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/atotto/clipboard"
   packages = ["."]
   revision = "bb272b845f1112e10117e3e45ce39f690c0001ad"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/sts"
+  ]
   revision = "d05c000e0b41647375a4093373eb1301e02c8a4e"
   version = "v1.10.22"
 
@@ -44,19 +69,19 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
-  branch = "master"
   name = "github.com/pkg/term"
-  packages = [".","termios"]
+  packages = [
+    ".",
+    "termios"
+  ]
   revision = "b1f72af2d63057363398bec5873d16a98b453312"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "b26b538f693051ac6518e65672de3144ce3fbedc"
@@ -74,20 +99,36 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["cast5","chacha20poly1305","chacha20poly1305/internal/chacha20","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","pbkdf2","poly1305","scrypt","ssh/terminal"]
+  packages = [
+    "cast5",
+    "chacha20poly1305",
+    "chacha20poly1305/internal/chacha20",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "pbkdf2",
+    "poly1305",
+    "scrypt",
+    "ssh/terminal"
+  ]
   revision = "b176d7def5d71bdd214203491f89843ed217f420"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "e42485b6e20ae7d2304ec72e535b103ed350cc02"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3b34d012cd3d49c0eac41e29eb7e1a7f6148ab90ce2d33349c339a626e955ce5"
+  inputs-digest = "74f73cabc4ba04745569525ccf177414d5b3ca09245aea06330e22fd7298dd1d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,28 +26,28 @@
   version = "0.3.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/atotto/clipboard"
+  revision = "bb272b845f1112e10117e3e45ce39f690c0001ad"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.10.41"
+  version = "v1.10.22"
 
 [[constraint]]
   name = "github.com/leonklingele/randomstring"
   version = "1.0.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/mitchellh/go-homedir"
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/pkg/term"
+  revision = "b1f72af2d63057363398bec5873d16a98b453312"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/spf13/cobra"
+  revision = "b26b538f693051ac6518e65672de3144ce3fbedc"
 
 [[constraint]]
   name = "github.com/spf13/pflag"
@@ -58,5 +58,5 @@
   version = "1.0.0"
 
 [[constraint]]
-  branch = "master"
   name = "golang.org/x/crypto"
+  revision = "b176d7def5d71bdd214203491f89843ed217f420"


### PR DESCRIPTION
Not pinning a dependency to a specific revision or version makes
adding new dependencies incredibly hard as dep always auto-updates
those non-pinned dependencies (previously using branch = "master").