### PR TITLE
README: Force-build from source when using Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go get -u github.com/bndw/pick
 #### Homebrew
 
 ```sh
-brew install bndw/pick/pick-pass
+brew install bndw/pick/pick-pass --build-from-source
 ```
 
 


### PR DESCRIPTION
This ensures that we ignore any precompiled Homebrew binaries if
available and always build from source as a security precaution.