### PR TITLE
backends: Use defaults even if config option was provided but empty

### DIFF
--- a/backends/file/new.go
+++ b/backends/file/new.go
@@ -22,14 +22,15 @@ func _new(config *backends.Config) (backends.Client, error) {
 		return nil, err
 	}
 
-	safePath, ok := config.Settings["path"].(string)
-	if ok {
-		safePath = formatHomeDir(safePath, homeDir)
-	} else {
+	safePath, _ := config.Settings["path"].(string)
+	// TODO: Should only check the `ok` variable! Current implementation is a workaround for https://github.com/spf13/viper/issues/472
+	if safePath == "" {
 		safePath, err = defaultSafePath(homeDir)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		safePath = formatHomeDir(safePath, homeDir)
 	}
 
 	// Adding support for paths relative to the default pick dir

--- a/backends/s3/new.go
+++ b/backends/s3/new.go
@@ -22,13 +22,15 @@ const (
 //		key:	 	 AWS S3 Key name for storing the safe. Defaults to `defaultS3Key`
 func _new(config *backends.Config) (backends.Client, error) {
 	// AWS S3 Bucket overrides
-	bucket, ok := config.Settings["bucket"].(string)
-	if !ok {
+	bucket, _ := config.Settings["bucket"].(string)
+	// TODO: Should only check the `ok` variable! Current implementation is a workaround for https://github.com/spf13/viper/issues/472
+	if bucket == "" {
 		bucket = defaultS3Bucket
 	}
 
-	key, ok := config.Settings["key"].(string)
-	if !ok {
+	key, _ := config.Settings["key"].(string)
+	// TODO: Should only check the `ok` variable! Current implementation is a workaround for https://github.com/spf13/viper/issues/472
+	if key == "" {
 		key = defaultS3Key
 	}
 	key = path.TrimModPrefix(key)

--- a/config/config.go
+++ b/config/config.go
@@ -51,10 +51,7 @@ func Load(rootCmd *cobra.Command, version string) (*Config, error) {
 
 	// Ugly, I know. See https://github.com/spf13/viper/issues/472
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if err := viper.ReadInConfig(); err != nil {
-			// Return `nil` to avoid printing an unneccesary error message
-			return nil
-		}
+		_ = viper.ReadInConfig()
 		if err := viper.Unmarshal(&config); err != nil {
 			return fmt.Errorf("failed to unmarshal into config: %v", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -49,9 +49,13 @@ func Load(rootCmd *cobra.Command, version string) (*Config, error) {
 	viper.BindPFlag("storage.settings.path", rootCmd.PersistentFlags().Lookup("safe")) // file backend
 	viper.BindPFlag("storage.settings.key", rootCmd.PersistentFlags().Lookup("safe"))  // s3 backend
 
-	// Ugly, I know. See https://github.com/spf13/viper/issues/472
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, fmt.Errorf("failed to read config file: %v", err)
+		}
+	}
+	// TODO: https://github.com/spf13/viper/issues/472
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		_ = viper.ReadInConfig()
 		if err := viper.Unmarshal(&config); err != nil {
 			return fmt.Errorf("failed to unmarshal into config: %v", err)
 		}


### PR DESCRIPTION
This is a workaround for #190