### PR TITLE
Makefile: adapt to Go 1.12 syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ gofmt:
 	GOPATH=$(GOPATH) go fmt $(FOLDERS)
 
 govet:
-	GOPATH=$(GOPATH) go tool vet $(FOLDERS)
+	GOPATH=$(GOPATH) go vet $(FOLDERS)
 
 config:
 	@if [ ! -f "$(PICK_DIR)/config.toml" ]; then \


### PR DESCRIPTION
"make govet" was failing with the following error message:

    vet: invoking "go tool vet" directly is unsupported; use "go vet"